### PR TITLE
chore: add run demo instructions

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -48,12 +48,12 @@ An example with a package named `react-foo`:
 > To import a stylesheet, one can import it on the project's entry CSS file:
 > ```css
 > /* src/index.css */
-> @import "@moxy/react-foo/styles";
+> @import "@moxy/react-foo/dist/index.css";
 > ```
 > ...or in the project's entry JavaScript file:
 > ```js
 > /* src/index.js */
-> import "@moxy/react-foo/styles/index.css";
+> import "@moxy/react-foo/dist/index.css";
 > ```
 
 ### Without CSS
@@ -62,7 +62,7 @@ If your package doesn't need any styling, you can trim it down to disable css su
 1. Delete `postcss.config.js` file.
 2. Delete `src/styles` folder.
 3. Remove `npm run build:css` from the `"build"` script in `package.json`.
-4. Remove `postcss-cli` from the dev dependencies list in `package.json`. 
+4. Remove `postcss-cli` from the dev dependencies list in `package.json`.
 4. Remove all imported css from the demo `/pages/_app.js`.
 
 ## DOD Checklist

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -63,7 +63,7 @@ If your package doesn't need any styling, you can trim it down to disable css su
 2. Delete `src/styles` folder.
 3. Remove `npm run build:css` from the `"build"` script in `package.json`.
 4. Remove `postcss-cli` from the dev dependencies list in `package.json`.
-4. Remove all imported css from the demo `/pages/_app.js`.
+5. Remove all imported css from the demo `/pages/_app.js`.
 
 ## DOD Checklist
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ $ npm test
 $ npm test -- --watch # during development
 ```
 
+## Demo
+
+A demo [Next.js](https://nextjs.org/) project is available in the [`/demo`](./demo) folder so you can try out this component.
+
+First, build the `{package-name}` project with:
+
+```sh
+$ npm run build
+```
+
+To run the demo, do the following inside the demo's folder:
+
+```sh
+$ npm i
+$ npm run dev
+```
+
 ## License
 
 Released under the [MIT License](https://www.opensource.org/licenses/mit-license.php).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [david-dm-dev-url]:https://david-dm.org/moxystudio/{package-name}?type=dev
 [david-dm-dev-image]:https://img.shields.io/david/dev/moxystudio/{package-name}.svg
 
-{package-drescription}
+{package-description}
 
 ## Installation
 
@@ -77,6 +77,8 @@ To run the demo, do the following inside the demo's folder:
 $ npm i
 $ npm run dev
 ```
+
+*Note: Everytime a change is made to the package a rebuild is required to reflect those changes on the demo.*
 
 ## License
 


### PR DESCRIPTION
Adds missing info in the `README.md` about how to properly run the demo, as it needs the project to be built and that step could be forgotten causing confusion.

Also, fixes a path in the `INSTRUCTIONS.md`.