### PR TITLE
fix: update eslint version due to no-implicit-globals rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@testing-library/react": "^10.0.2",
     "commitlint": "^8.3.5",
     "cross-env": "^7.0.2",
-    "eslint": "^6.0.0",
+    "eslint": "^6.7.0",
     "husky": "^4.0.10",
     "jest": "^25.2.6",
     "lint-staged": "^10.0.2",


### PR DESCRIPTION
Update eslint version to avoid having a configuration error in rule `no-implicit-globals` from `@moxy/eslint-config-base`.


**Read entire description here:**
https://github.com/moxystudio/eslint-config/pull/96